### PR TITLE
Add --dep flag to create command and clarify --parent documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `--dep` flag for `create` command to add initial dependency at creation time
+
 ### Changed
 
 - Clarified `--parent` flag documentation: advisory metadata for epic/subtask hierarchy, not a blocking dependency

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Commands:
     -p, --priority         Priority 0-4, 0=highest [default: 2]
     -a, --assignee         Assignee [default: git user.name]
     --external-ref         External reference (e.g., gh-123, JIRA-456)
-    --parent               Parent ticket ID
+    --parent               Parent ticket ID (advisory, for epic/subtask hierarchy)
+    --dep                  Initial dependency (ticket must be completed first)
   start <id>               Set status to in_progress
   close <id>               Set status to closed
   reopen <id>              Set status to open

--- a/ticket
+++ b/ticket
@@ -114,6 +114,7 @@ cmd_create() {
 
     local title="" description="" design="" acceptance=""
     local priority=2 issue_type="task" assignee="" external_ref="" parent=""
+    local initial_dep=""
 
     # Default assignee to git user.name if available
     assignee=$(git config user.name 2>/dev/null || true)
@@ -129,6 +130,7 @@ cmd_create() {
             -a|--assignee) assignee="$2"; shift 2 ;;
             --external-ref) external_ref="$2"; shift 2 ;;
             --parent) parent="$2"; shift 2 ;;
+            --dep) initial_dep="$2"; shift 2 ;;
             -*) echo "Unknown option: $1" >&2; return 1 ;;
             *) title="$1"; shift ;;
         esac
@@ -141,11 +143,21 @@ cmd_create() {
     local now
     now=$(_iso_date)
 
+    # Resolve initial dependency if provided
+    local deps_value="[]"
+    if [[ -n "$initial_dep" ]]; then
+        local dep_file
+        dep_file=$(ticket_path "$initial_dep") || return 1
+        local dep_id
+        dep_id=$(yaml_field "$dep_file" "id")
+        deps_value="[$dep_id]"
+    fi
+
     {
         echo "---"
         echo "id: $id"
         echo "status: open"
-        echo "deps: []"
+        echo "deps: $deps_value"
         echo "links: []"
         echo "created: $now"
         echo "type: $issue_type"
@@ -1199,7 +1211,8 @@ Commands:
     -p, --priority         Priority 0-4, 0=highest [default: 2]
     -a, --assignee         Assignee
     --external-ref         External reference (e.g., gh-123, JIRA-456)
-    --parent               Parent ticket ID
+    --parent               Parent ticket ID (advisory, for epic/subtask hierarchy)
+    --dep                  Initial dependency (ticket must be completed first)
   start <id>               Set status to in_progress
   close <id>               Set status to closed
   reopen <id>              Set status to open


### PR DESCRIPTION
## Summary

This PR clarifies the distinction between parent relationships and dependencies, and adds a new `--dep` flag for convenience when creating tickets.

## Changes

### Documentation: Clarify `--parent` flag

The `--parent` flag tracks epic/subtask organizational hierarchy and is purely advisory metadata. It does not create blocking dependencies. This distinction (inspired by [beads CLI dependency types](https://github.com/steveyegge/beads/blob/main/docs/CLI_REFERENCE.md#dependency-types)) is now documented in the help output, README, and CHANGELOG.

If a child ticket should be blocked by its parent (or any other ticket), that dependency must be explicitly added.

### Feature: Add `--dep` flag to `create` command

To make adding dependencies at creation time easier, the new `--dep` flag allows specifying an initial blocking dependency:

```bash
# Create a subtask that is both a child of and blocked by an epic
tk create "Implement feature" --parent epic-id --dep epic-id

The dependency is resolved and added to the deps array in the ticket frontmatter.